### PR TITLE
Added ticket notification for moderators v2

### DIFF
--- a/backend/src/guild/events/interaction-create/mod-request-menu/index.ts
+++ b/backend/src/guild/events/interaction-create/mod-request-menu/index.ts
@@ -5,6 +5,7 @@ import {
   ModalSubmitInteraction,
   EmbedBuilder,
   userMention,
+  roleMention,
   StringSelectMenuInteraction,
   ModalBuilder,
   ActionRowBuilder,
@@ -121,8 +122,7 @@ export class ModRequestFlow {
         ),
       ],
     });
-    await channel.send(userMention(interaction.user.id));
-    await channel.send('<@&1405801201316003891>');
+    await channel.send(`${userMention(interaction.user.id)} ${roleMention('1405801201316003891')}`);
     await interaction.editReply({
       content: 'Deine Mod Anfrage wurde erfolgreich versendet.',
     });

--- a/backend/src/guild/events/interaction-create/mod-request-menu/index.ts
+++ b/backend/src/guild/events/interaction-create/mod-request-menu/index.ts
@@ -122,6 +122,7 @@ export class ModRequestFlow {
       ],
     });
     await channel.send(userMention(interaction.user.id));
+    await channel.send('<@&1405801201316003891>');
     await interaction.editReply({
       content: 'Deine Mod Anfrage wurde erfolgreich versendet.',
     });


### PR DESCRIPTION
Moderation can now pick a role to get notified when a new ticket was created. 
- Using roleMention() and both pings in one line.